### PR TITLE
Update boss talents guide to simplify description

### DIFF
--- a/src/app/components/guides/boss-talents/boss-talents-guide.component.html
+++ b/src/app/components/guides/boss-talents/boss-talents-guide.component.html
@@ -67,7 +67,7 @@
           <span class="track-badge track-strategic">
             <i class="bi bi-bullseye"></i> Strategic
           </span>
-          – Generic damage/healing bonuses or challenge-mode clear counts.
+          – Generic damage/healing bonuses.
         </li>
       </ul>
 


### PR DESCRIPTION
Removed reference to challenge-mode clear counts from the boss talents guide.